### PR TITLE
Port forwarding server setup with correct options

### DIFF
--- a/src/manager/port-forward-manager.ts
+++ b/src/manager/port-forward-manager.ts
@@ -16,7 +16,11 @@ class PortForwardManager implements Disposable {
             const forwarder = new PortForward(cluster.client.getConfig(), true);
             const response = await cluster.client.getServiceWithPortForwardInfo(service, namespace);
 
-            const server = createServer(function (socket) {
+            const server = createServer({
+                allowHalfOpen: true,
+                noDelay: true,
+                keepAlive: true
+            }, function (socket) {
                 forwarder.portForward(namespace, response.pod, [response.targetPort], socket, socket, socket);
             });
 


### PR DESCRIPTION
Previously, the port forwarding server would use incorrect options meaning that the server would timeout eventually. This change should help mitigate that. 